### PR TITLE
Added OpenBLAS dependency

### DIFF
--- a/.github/workflows/cmake-build-test.yml
+++ b/.github/workflows/cmake-build-test.yml
@@ -53,8 +53,8 @@ jobs:
           cache-name: cache-dependencies
         with:
           path: ${{ steps.build_dir.outputs.build-output-dir }}
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ matrix.build_type }}-${{ hashFiles(steps.deps_file.outputs.dependencies-file) }}
-          restore-keys: ${{ runner.os }}-build-${{ env.cache-name }}-${{ matrix.build_type }}-
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{matrix.os}}-${{ matrix.cpp_compiler }}-${{ hashFiles(steps.deps_file.outputs.dependencies-file) }}
+          restore-keys: ${{ runner.os }}-build-${{ env.cache-name }}-${{matrix.os}}-${{ matrix.cpp_compiler }}-
       - name: Configure CMake
         run: >
           cmake -B ${{ steps.build_dir.outputs.build-output-dir }}
@@ -63,7 +63,6 @@ jobs:
           -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
           -S ${{ github.workspace }}
       - name: Build
-        # Build your program with the given configuration. Note that --config is needed because the default Windows generator is a multi-config generator (Visual Studio generator).
         run: cmake --build ${{ steps.build_dir.outputs.build-output-dir }} --config ${{ matrix.build_type }}
       - name: Test
         working-directory: ${{ steps.build_dir.outputs.build-output-dir }}

--- a/.github/workflows/cmake-build-test.yml
+++ b/.github/workflows/cmake-build-test.yml
@@ -32,26 +32,39 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - name: Set reusable strings
-        # Turn repeated input strings (such as the build output directory) into step outputs. These step outputs can be used throughout the workflow file.
-        id: strings
+
+      - name: Set Build Directory
+        id: build_dir
+        shell: bash
+        run: echo "build-output-dir=${{ github.workspace }}/build" >> "$GITHUB_OUTPUT"
+      - name: Set Dependency File
+        id: deps_file
+        shell: bash
+        run: echo "dependencies-file=${{ github.workspace }}/dependencies.txt" >> "$GITHUB_OUTPUT"
+      - name: Extract Dependencies
+        id: deps
         shell: bash
         run: |
-          echo "build-output-dir=${{ github.workspace }}/build" >> "$GITHUB_OUTPUT"
-      - name: Install Dependencies
-        run: sudo apt install libopenblas-dev -y
+          grep -Eo "URL \S+$" CMakeLists.txt | cut -d ' ' -f 2 > ${{ steps.deps_file.outputs.dependencies-file }}
+      - name: Load Dependencies from Cache
+        id: cache-cmake
+        uses: actions/cache@v3
+        env:
+          cache-name: cache-dependencies
+        with:
+          path: ${{ steps.build_dir.outputs.build-output-dir }}
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ matrix.build_type }}-${{ hashFiles(steps.deps_file.outputs.dependencies-file) }}
+          restore-keys: ${{ runner.os }}-build-${{ env.cache-name }}-${{ matrix.build_type }}-
       - name: Configure CMake
-        # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
-        # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
         run: >
-          cmake -B ${{ steps.strings.outputs.build-output-dir }}
+          cmake -B ${{ steps.build_dir.outputs.build-output-dir }}
           -DCMAKE_CXX_COMPILER=${{ matrix.cpp_compiler }}
           -DCMAKE_C_COMPILER=${{ matrix.c_compiler }}
           -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
           -S ${{ github.workspace }}
       - name: Build
         # Build your program with the given configuration. Note that --config is needed because the default Windows generator is a multi-config generator (Visual Studio generator).
-        run: cmake --build ${{ steps.strings.outputs.build-output-dir }} --config ${{ matrix.build_type }}
+        run: cmake --build ${{ steps.build_dir.outputs.build-output-dir }} --config ${{ matrix.build_type }}
       - name: Test
-        working-directory: ${{ steps.strings.outputs.build-output-dir }}
+        working-directory: ${{ steps.build_dir.outputs.build-output-dir }}
         run: ctest --build-config ${{ matrix.build_type }}

--- a/.github/workflows/cmake-build-test.yml
+++ b/.github/workflows/cmake-build-test.yml
@@ -38,6 +38,8 @@ jobs:
         shell: bash
         run: |
           echo "build-output-dir=${{ github.workspace }}/build" >> "$GITHUB_OUTPUT"
+      - name: Install Dependencies
+        run: sudo apt install libopenblas-dev -y
       - name: Configure CMake
         # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
         # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type

--- a/.github/workflows/cmake-build-test.yml
+++ b/.github/workflows/cmake-build-test.yml
@@ -63,7 +63,9 @@ jobs:
           -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
           -S ${{ github.workspace }}
       - name: Build
-        run: cmake --build ${{ steps.build_dir.outputs.build-output-dir }} --config ${{ matrix.build_type }}
+        env:
+          njobs: 12
+        run: cmake --build ${{ steps.build_dir.outputs.build-output-dir }} --config ${{ matrix.build_type }} -- -j ${{ env.njobs }}
       - name: Test
         working-directory: ${{ steps.build_dir.outputs.build-output-dir }}
         run: ctest --build-config ${{ matrix.build_type }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,18 @@ FetchContent_Declare(
 set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
 FetchContent_MakeAvailable(googletest)
 
+# Find and link OpenBLAS
+find_package(
+    OpenBLAS_CMAKE
+    REQUIRED
+    NAMES OpenBLAS
+    PATHS /opt/OpenBLAS/lib/cmake)
+if(OpenBLAS_CMAKE_FOUND)
+    message(STATUS "OpenBLAS Version: ${OpenBLAS_VERSION}")
+    message(STATUS "OpenBLAS Library: ${OpenBLAS_LIBRARIES}")
+    message(STATUS "OpenBLAS Include Directory: ${OpenBLAS_INCLUDE_DIRS}")
+endif()
+
 # Resolve system specific options
 if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror -Wconversion -pthread")
@@ -40,6 +52,8 @@ endif ()
 message(STATUS "Found system \"${CMAKE_SYSTEM_NAME}\", using flags: ${CMAKE_CXX_FLAGS}")
 
 add_executable(singularity singularity/main.cpp)
+target_include_directories(singularity PRIVATE ${OpenBLAS_INCLUDE_DIRS})
+target_link_libraries(singularity ${OpenBLAS_LIBRARIES})
 
 enable_testing()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,8 +2,14 @@ cmake_minimum_required(VERSION 3.14)
 project(singularity LANGUAGES CXX)
 
 if (POLICY CMP0077)
-  cmake_policy (SET CMP0077 NEW)
+    cmake_policy(SET CMP0077 NEW)
 endif (POLICY CMP0077)
+
+if (POLICY CMP0135)
+    cmake_policy(SET CMP0135 NEW)
+endif (POLICY CMP0135)
+
+message(STATUS "Starting configuration process in directory ${CMAKE_CURRENT_SOURCE_DIR}")
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/build")
@@ -15,47 +21,42 @@ set(CMAKE_CXX_FLAGS "-Wall")
 # Fetch requisite dependencies
 include(FetchContent)
 FetchContent_Declare(
-  googletest
-  URL https://github.com/google/googletest/archive/03597a01ee50ed33e9dfd640b249b4be3799d395.zip
-)
-set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
-FetchContent_MakeAvailable(googletest)
-
-# Fetch requisite dependencies
-include(FetchContent)
-FetchContent_Declare(
         googletest
         URL https://github.com/google/googletest/archive/refs/tags/v1.14.0.zip
 )
 set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
 
-# Find and link OpenBLAS
-find_package(
-    OpenBLAS_CMAKE
-    REQUIRED
-    NAMES OpenBLAS
-    PATHS /opt/OpenBLAS/lib/cmake)
-if(OpenBLAS_CMAKE_FOUND)
-    message(STATUS "OpenBLAS Version: ${OpenBLAS_VERSION}")
-    message(STATUS "OpenBLAS Library: ${OpenBLAS_LIBRARIES}")
-    message(STATUS "OpenBLAS Include Directory: ${OpenBLAS_INCLUDE_DIRS}")
-endif()
+FetchContent_Declare(
+    openblas
+    URL https://github.com/OpenMathLib/OpenBLAS/archive/refs/tags/v0.3.27.tar.gz
+    URL_HASH MD5=ef71c66ffeb1ab0f306a37de07d2667f 
+)
+
+# Set OpenBLAS configure options
+set(BUILD_TESTING OFF)
+set(BUILD_LAPACK_DEPRECATED OFF)
+set(BUILD_STATIC_LIBS ON)
+set(ONLY_CBLAS ON)
+
+FetchContent_MakeAvailable(googletest openblas)
 
 # Resolve system specific options
-if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror -Wconversion -pthread")
-elseif(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+elseif (CMAKE_SYSTEM_NAME STREQUAL "Darwin")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror -Wconversion")
-endif()
+endif ()
 
 if (CMAKE_CXX_COMPILE_ID STREQUAL "Clang")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++")
 endif ()
 
-message(STATUS "Found system \"${CMAKE_SYSTEM_NAME}\", using flags: ${CMAKE_CXX_FLAGS}")
+message(STATUS "Found system \"${CMAKE_SYSTEM_NAME}\", using flags: ${CMAKE_CXX_FLAGS} ")
 
 add_executable(singularity singularity/main.cpp)
 target_link_libraries(singularity openblas_static)
+target_include_directories(singularity PRIVATE "${CMAKE_CURRENT_BINARY_DIR}/generated")
+target_include_directories(singularity PRIVATE "${CMAKE_CURRENT_BINARY_DIR}")
 
 enable_testing()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,10 @@
 cmake_minimum_required(VERSION 3.14)
 project(singularity LANGUAGES CXX)
 
+if (POLICY CMP0077)
+  cmake_policy (SET CMP0077 NEW)
+endif (POLICY CMP0077)
+
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/build")
 
@@ -21,10 +25,9 @@ FetchContent_MakeAvailable(googletest)
 include(FetchContent)
 FetchContent_Declare(
         googletest
-        URL https://github.com/google/googletest/archive/03597a01ee50ed33e9dfd640b249b4be3799d395.zip
+        URL https://github.com/google/googletest/archive/refs/tags/v1.14.0.zip
 )
 set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
-FetchContent_MakeAvailable(googletest)
 
 # Find and link OpenBLAS
 find_package(
@@ -52,8 +55,7 @@ endif ()
 message(STATUS "Found system \"${CMAKE_SYSTEM_NAME}\", using flags: ${CMAKE_CXX_FLAGS}")
 
 add_executable(singularity singularity/main.cpp)
-target_include_directories(singularity PRIVATE ${OpenBLAS_INCLUDE_DIRS})
-target_link_libraries(singularity ${OpenBLAS_LIBRARIES})
+target_link_libraries(singularity openblas_static)
 
 enable_testing()
 

--- a/singularity/main.cpp
+++ b/singularity/main.cpp
@@ -1,5 +1,17 @@
+#include <cblas.h>
+
 #include <iostream>
 
-int main() { 
+int main() {
     std::cout << "Hello from singularity!" << std::endl;
+
+    int i = 0;
+    double A[4] = {1.0, 2.0, 1.0, -3.0};
+    double B[4] = {2.0, 0.0, 0.0, 0.5};
+    double C[4] = {.5, .5, .5, .5};
+    cblas_dgemm(CblasRowMajor, CblasNoTrans, CblasNoTrans, 2, 2, 2, 1, A, 2, B,
+                2, 0, C, 2);
+
+    for (i = 0; i < 4; i++) printf("%lf ", C[i]);
+    printf("\n");
 }


### PR DESCRIPTION
Uses `FetchContent` to download and build OpenBLAS. Slower than local install, but is easier to setup across platforms. In future, can be updated to take advantage of `find_package` behavior in multiplatform situations.